### PR TITLE
fix: vscode mcp

### DIFF
--- a/.changeset/bold-pigs-jog.md
+++ b/.changeset/bold-pigs-jog.md
@@ -1,0 +1,5 @@
+---
+"google-workspace-developer-tools": patch
+---
+
+Fix contributes.mcpServerDefinitionProviders for MCP server.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -40,7 +40,13 @@
   "type": "module",
   "main": "./out/extension.cjs",
   "contributes": {
-    "commands": []
+    "commands": [],
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "google-workspace-developer",
+        "label": "Google Workspace Developer Tools"
+      }
+    ]
   },
   "activationEvents": [
     "onStartupFinished"


### PR DESCRIPTION
MCP server wasn't registered correctly as part of the VS Code extension.